### PR TITLE
Fix Dist::Zilla build and fix breakage due to removal of List::MoreUtils from Moose.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+README.mkdn

--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+{{$NEXT}}
+
 1.1.2 - 2011-09-17
   - fixed bug where the dependency parameter would swallow all subsequent parameters
 

--- a/Changes
+++ b/Changes
@@ -1,4 +1,6 @@
 {{$NEXT}}
+  - fix breakage with recent Moose > 2.1700 dues to removal of List::MoreUtils
+    from Moose.
 
 1.1.2 - 2011-09-17
   - fixed bug where the dependency parameter would swallow all subsequent parameters

--- a/dist.ini
+++ b/dist.ini
@@ -3,21 +3,22 @@ author  = Moritz Onken
 license = BSD
 copyright_holder = Moritz Onken
 
-version = 1.1.2
+version = 1.1.3
 
 [@Filter]
--bundle = @JQUELIN
+-bundle = @Author::JQUELIN
 -remove = AutoVersion
--remove = AutoPrereqs
+-remove = CheckChangeLog
+-remove = Git::NextVersion
+-remove = NextRelease
 
-[Prereqs]
-Moose = 0
-Moose::Exporter = 0
-Moose::Role = 0
-Moose::Util::MetaRole = 0
-overload = 0
-File::Find = 0
-File::Temp = 0
+[Prereqs / BuildRequires]
 Module::Build = 0.3601
+
+[Prereqs / TestRequires]
 Test::More = 0.88
 Test::Most = 0.23
+
+[NextRelease]
+format    = %-5v - %{yyyy-MM-dd}d
+time_zone = GMT

--- a/lib/MooseX/Attribute/Dependency.pm
+++ b/lib/MooseX/Attribute/Dependency.pm
@@ -32,6 +32,7 @@ __PACKAGE__->meta->make_immutable;
 package MooseX::Attribute::Dependencies;
 use strict;
 use warnings;
+use List::MoreUtils ();
 
 MooseX::Attribute::Dependency::register(
     {   name       => 'All',

--- a/t/synopsis.t
+++ b/t/synopsis.t
@@ -1,5 +1,6 @@
 package MyApp::Types;
 use MooseX::Attribute::Dependency;
+use List::MoreUtils ();
 
 BEGIN { MooseX::Attribute::Dependency::register({
        name               => 'SmallerThan',


### PR DESCRIPTION
These commits fix two problems:

1: List::MoreUtils is no longer required by Moose as of 2.1800.  This means that you can no longer assume that "use Moose" pulled in List::MoreUtils.  You cannot even assume that List::MoreUtils has been installed.  I added "use List::MoreUtils ();" where necessary, and its now a dependency of the dist (via AutoPrereqs).

2: the dist cannot be created using Dist::Zilla because pluginbundle @JQUELIN no longer exists on CPAN.  It has been renamed to @Author::JQUELIN.  We use that instead.  I had to make some minor changes to dist.ini to be compatible with the newer pluginbundle.

All tests pass.  Please build a new dist and upload to cpan so that we can have a working version of this Moose extension again.

If you no longer have time to work on this dist (I note that there are no updates to this module in 5 years), feel free to add me as COMAINT in PAUSE so that I can upload a fixed version.

Thanks!
